### PR TITLE
ID and name separator inconsistency with the readme file

### DIFF
--- a/src/android/org/rti/tangerine/p2p/NearbyConnectionsPlugin.java
+++ b/src/android/org/rti/tangerine/p2p/NearbyConnectionsPlugin.java
@@ -253,7 +253,7 @@ public class NearbyConnectionsPlugin extends CordovaPlugin
                         String endpointString = "";
                         try {
                             endpointString = args.getString(0);
-                            String[] epArray = endpointString.split("~");
+                            String[] epArray = endpointString.split("_");
                             String id = epArray[0];
                             String name = epArray[1];
                             Endpoint endpoint = new Endpoint(id, name);


### PR DESCRIPTION
In the readme.md file

https://github.com/Tangerine-Community/cordova-plugin-nearby-connections/blob/6a24777f3fa346354a436f13f94f57168ac43fe3/README.md#L154

a different speparator is used compared to the java code.